### PR TITLE
Update notes.tex

### DIFF
--- a/topic00_computation_LinearAlgebra/notes.tex
+++ b/topic00_computation_LinearAlgebra/notes.tex
@@ -678,7 +678,7 @@ but no support for sparse matrices.
         \item $A (\trans A A)^{-1}$
             \vspace{4in}
             \newpage
-        \item $\lF{A \trans A A \x}^2$
+        \item $\|A \trans A A \x\|^2$ % Frobenius norm is a matrix norm, but the output of the product is a vector
             \vspace{4in}
             \newpage
         \item $\lF{(\lambda I + A) \x \trans \x}$


### PR DESCRIPTION
Frobenius norm is a matrix norm, but the output of the product is a vector. Changed to L2 norm.